### PR TITLE
Don't hardcode paths

### DIFF
--- a/examples/marswm.desktop
+++ b/examples/marswm.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=MarsWM
 Comment=A modern window manager featuring dynamic tiling.
-Exec=/usr/local/bin/marswm
-TryExec=/usr/local/bin/marswm
+Exec=marswm
+TryExec=marswm
 Type=Application


### PR DESCRIPTION
Linux mostly uses `/usr/bin` with some exceptions that use `/usr/local/bin`, FreeBSD and OpenBSD use `/usr/local/bin`.

But, we (NetBSD) believe that `/usr/local/bin` should be **what it says on the label**, _i.e._ a place where you can install things you build yourself, think `opt` on Linux. Therefor, our packages are installed into `/usr/pkg/bin`.

So, let's not hardcode `${PATH}` and let's assume the package is installed to the correct path, independently of what system we are installing on.