### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,33 +19,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -87,15 +87,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "equivalent"
@@ -105,9 +105,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -117,9 +117,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -133,22 +133,22 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libmars"
 version = "0.5.3"
 dependencies = [
  "serde",
- "serde_yaml_ng",
+ "serde_norway",
  "x11",
  "xdg",
 ]
@@ -184,15 +184,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -214,18 +214,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -233,10 +233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
+name = "serde_norway"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+checksum = "fd5e0553e618ffcfb844e6aadd70c2366da7fa81a5456add838e57815df04de2"
 dependencies = [
  "indexmap",
  "itoa",
@@ -253,9 +253,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -282,9 +282,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ license-file = "LICENSE"
 readme = "README.md"
 
 [workspace.dependencies]
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.21", features = ["derive"] }
 libmars = { path = "./libmars", version = "0.5.3" }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_yaml_ng = { version = "0.10.0" }
+serde = { version = "1.0.215", features = ["derive"] }
+serde_norway = { version = "0.9.39" }
 x11 = { version = "2.21.0", features = ["xlib"] }
 
 

--- a/libmars/Cargo.toml
+++ b/libmars/Cargo.toml
@@ -13,11 +13,11 @@ readme.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"], optional = true }
-serde_yaml_ng = { workspace = true, optional = true }
+serde_norway = { workspace = true, optional = true }
 x11 = { workspace = true, features = ["xinerama", "xrandr", "xft"] }
-xdg = { version = "2.4.1", optional = true }
+xdg = { version = "2.5.2", optional = true }
 
 [features]
-configuration = ["dep:serde", "dep:serde_yaml_ng", "dep:xdg"]
+configuration = ["dep:serde", "dep:serde_norway", "dep:xdg"]
 xlib = []  # TODO implement configuration option
 

--- a/libmars/src/utils/configuration.rs
+++ b/libmars/src/utils/configuration.rs
@@ -1,4 +1,4 @@
-//! Loading configuration files using [serde_yaml_ng].
+//! Loading configuration files using [serde_norway].
 
 use std::fs;
 use std::path;
@@ -12,7 +12,7 @@ fn deserialize_file<T: for<'a> Deserialize<'a>>(path: &path::Path) -> Result<T, 
         Err(e) => return Err((true, e.to_string())),
     };
 
-    match serde_yaml_ng::from_slice(&raw) {
+    match serde_norway::from_slice(&raw) {
         Ok(config) => Ok(config),
         Err(e) => Err((true, e.to_string())),
     }
@@ -20,7 +20,7 @@ fn deserialize_file<T: for<'a> Deserialize<'a>>(path: &path::Path) -> Result<T, 
 
 /// Print config files to stdout
 pub fn print_config(config: &impl Serialize) {
-    let ser = serde_yaml_ng::to_string(config);
+    let ser = serde_norway::to_string(config);
     match ser {
         Ok(ser) => println!("{}", ser),
         Err(e) => eprintln!("Error: {}", e),


### PR DESCRIPTION
Change to serde_norway, https://github.com/cafkafk/serde-norway which is apparently more actively maintained.

@jzbor This builds for me when using `cargo build` with one single warning:
```
warning: trait `CreateWidget` is never used
  --> marsbar/src/config.rs:19:11
   |
19 | pub trait CreateWidget<W: Widget> {
   |           ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `marsbar` (bin "marsbar") generated 1 warning
```

Rust version 1.82

`cargo clippy` isn't happy, though 😞 
The log is a bit long, could you have a look? I'm still an happy user of `marswm` and would like to contribute within my basic understanding. Thanks!

```
    Checking libmars v0.5.3 (/home/pin/Git/marswm/libmars)
error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/control.rs:28:48
   |
28 |         let root = unsafe { XDefaultRootWindow(display) };
   |                                                ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
   = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/draw/canvas.rs:39:52
   |
39 |         let screen = unsafe { xlib::XDefaultScreen(display) };
   |                                                    ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/draw/canvas.rs:43:53
   |
43 |             .map_err(|e| unsafe { xlib::XFreePixmap(display, pixbuffer); e })?;
   |                                                     ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: using `map_err` over `inspect_err`
  --> libmars/src/platforms/x11/draw/canvas.rs:43:14
   |
43 |             .map_err(|e| unsafe { xlib::XFreePixmap(display, pixbuffer); e })?;
   |              ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
   = note: `#[warn(clippy::manual_inspect)]` on by default
help: try
   |
43 -             .map_err(|e| unsafe { xlib::XFreePixmap(display, pixbuffer); e })?;
43 +             .inspect_err(|e| unsafe { xlib::XFreePixmap(display, pixbuffer); })?;
   |

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/draw/canvas.rs:92:34
   |
92 |                 xlib::XNextEvent(display, event.as_mut_ptr());
   |                                  ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: this function has too many arguments (9/7)
  --> libmars/src/platforms/x11/draw/widget.rs:70:5
   |
70 | /     pub fn new(display: *mut xlib::Display, parent: xlib::Window, x: i32, y: i32, hpad: u32, vpad: u32, ipad: u32,
71 | |                children: Vec<W>, bg_color: u64) -> Result<X11FlowLayoutWidget<W>> {
   | |_________________________________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
   = note: `#[warn(clippy::too_many_arguments)]` on by default

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/draw/widget.rs:75:58
   |
75 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
   |                                                          ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/draw/widget.rs:79:58
   |
79 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
   |                                                          ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: using `map_err` over `inspect_err`
  --> libmars/src/platforms/x11/draw/widget.rs:75:14
   |
75 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
   |              ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
help: try
   |
75 -             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
75 +             .inspect_err(|err| unsafe { xlib::XDestroyWindow(display, window); })?;
   |

warning: using `map_err` over `inspect_err`
  --> libmars/src/platforms/x11/draw/widget.rs:79:14
   |
79 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
   |              ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
help: try
   |
79 -             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
79 +             .inspect_err(|err| unsafe { xlib::XDestroyWindow(display, window); })?;
   |

warning: this function has too many arguments (10/7)
   --> libmars/src/platforms/x11/draw/widget.rs:170:5
    |
170 | /     pub fn new(display: *mut xlib::Display, parent: xlib::Window, x: i32, y: i32, hpad: u32, vpad: u32,
171 | |                label: String, font: &str, fg_color: u64, bg_color: u64) -> Result<X11TextWidget> {
    | |________________________________________________________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:176:58
    |
176 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
    |                                                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:181:58
    |
181 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
    |                                                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: using `map_err` over `inspect_err`
   --> libmars/src/platforms/x11/draw/widget.rs:176:14
    |
176 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
    |              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
help: try
    |
176 -             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
176 +             .inspect_err(|err| unsafe { xlib::XDestroyWindow(display, window); })?;
    |

warning: using `map_err` over `inspect_err`
   --> libmars/src/platforms/x11/draw/widget.rs:181:14
    |
181 |             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
    |              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
help: try
    |
181 -             .map_err(|err| unsafe { xlib::XDestroyWindow(display, window); err })?;
181 +             .inspect_err(|err| unsafe { xlib::XDestroyWindow(display, window); })?;
    |

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:406:43
    |
406 |         let screen = xlib::XDefaultScreen(display);
    |                                           ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:409:45
    |
409 |         let win = xlib::XCreateSimpleWindow(display, xlib::XDefaultRootWindow(display),
    |                                             ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:409:79
    |
409 |         let win = xlib::XCreateSimpleWindow(display, xlib::XDefaultRootWindow(display),
    |                                                                               ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:411:58
    |
411 | ...                   xlib::XBlackPixel(display, screen),
    |                                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:412:58
    |
412 | ...                   xlib::XWhitePixel(display, screen));
    |                                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:417:28
    |
417 |         xlib::XSelectInput(display, win, mask);
    |                            ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:420:44
    |
420 |         let status = xlib::XReparentWindow(display, win, parent, dimensions.x(), dimensions.y());
    |                                            ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:422:34
    |
422 |             xlib::XDestroyWindow(display, win);
    |                                  ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:427:26
    |
427 |         xlib::XMapWindow(display, win);
    |                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/draw/widget.rs:430:22
    |
430 |         xlib::XFlush(display);
    |                      ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/atoms.rs:124:49
    |
124 |             let raw_string = xlib::XGetAtomName(display, atom);
    |                                                 ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/atoms.rs:139:31
    |
139 |             xlib::XInternAtom(display, atom_name, xlib::False)
    |                               ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/atoms.rs:146:43
    |
146 |         let name_ptr = xlib::XGetAtomName(display, atom);
    |                                           ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:47:43
   |
47 |             if xlib::XGetWindowAttributes(display, *self, attributes.as_mut_ptr()) != 0 {
   |                                           ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:58:46
   |
58 |             let status = xlib::XGetClassHint(display, *self, class_hints.as_mut_ptr());
   |                                              ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:88:35
   |
88 |                 xlib::XGrabServer(display);
   |                                   ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:90:41
   |
90 |                 xlib::XSetCloseDownMode(display, xlib::DestroyAll);
   |                                         ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:91:35
   |
91 |                 xlib::XKillClient(display, *self);
   |                                   ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:92:29
   |
92 |                 xlib::XSync(display, xlib::False);
   |                             ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/window.rs:94:37
   |
94 |                 xlib::XUngrabServer(display);
   |                                     ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:101:34
    |
101 |             xlib::XDestroyWindow(display, *self);
    |                                  ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:116:39
    |
116 |             if xlib::XGetTextProperty(display, *self, text.as_mut_ptr(), property.to_xlib_atom(display)) == 0 {
    |                                       ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:118:57
    |
118 |             } else if xlib::Xutf8TextPropertyToTextList(display, text.as_ptr(), &mut data_ptr, &mut nitems) != 0 {
    |                                                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: match can be simplified with `.unwrap_or_default()`
   --> libmars/src/platforms/x11/misc/window.rs:148:26
    |
148 |           let mut states = match states_result {
    |  __________________________^
149 | |             Ok(states) => states,
150 | |             Err(_) => Vec::new(),
151 | |         };
    | |_________^ help: replace it with: `states_result.unwrap_or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default
    = note: `#[warn(clippy::manual_unwrap_or_default)]` on by default

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:183:55
    |
183 |                 let status = xlib::XGetWindowProperty(display, *self, property.to_xlib_atom(display),
    |                                                       ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: accessing first element with `v.get(0)`
   --> libmars/src/platforms/x11/misc/window.rs:208:15
    |
208 |         match v.get(0) {
    |               ^^^^^^^^ help: try: `v.first()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
    = note: `#[warn(clippy::get_first)]` on by default

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:216:35
    |
216 |             xlib::XChangeProperty(display,
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:232:35
    |
232 |             xlib::XChangeProperty(display, *self, state_atom, state_atom,
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:245:47
    |
245 |             xlib::Xutf8TextListToTextProperty(display, slice.as_mut_ptr(), size, xlib::XUTF8StringStyle, text.as_mut_ptr());
    |                                               ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:246:36
    |
246 |             xlib::XSetTextProperty(display, *self, &mut text.assume_init(), property.to_xlib_atom(display));
    |                                    ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:264:35
    |
264 |             if xlib::XGetGeometry(display, *self, &mut root, &mut x, &mut y, &mut w, &mut h, &mut bw, &mut depth) != 0 {
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:282:51
    |
282 |             let result = xlib::XGetWindowProperty(display, *self, NetWMWindowType.to_xlib_atom(display),
    |                                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:296:46
    |
296 |             match xlib::XGetTransientForHint(display, *self, &mut window) {
    |                                              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:305:30
    |
305 |             xlib::XMapWindow(display, *self);
    |                              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:325:30
    |
325 |             xlib::XSendEvent(display, *self, xlib::False, 0, &mut event);
    |                              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:335:32
    |
335 |             xlib::XUnmapWindow(display, *self);
    |                                ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:344:35
    |
344 |             xlib::XGetWMProtocols(display, *self, &mut atoms, &mut natoms);
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/window.rs:360:40
    |
360 |             if xlib::XGetWMNormalHints(display, *self, size_hints.as_mut_ptr(), &mut supplied_hints) != 0 {
    |                                        ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/mod.rs:68:47
   |
68 |         let w = unsafe { xlib::XWidthOfScreen(screen).try_into().unwrap() };
   |                                               ^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/mod.rs:69:48
   |
69 |         let h = unsafe { xlib::XHeightOfScreen(screen).try_into().unwrap() };
   |                                                ^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> libmars/src/platforms/x11/misc/mod.rs:91:30
   |
91 |             xlib::XNextEvent(display, event.as_mut_ptr());
   |                              ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:105:33
    |
105 |             xlib::XCloseDisplay(display);
    |                                 ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:115:43
    |
115 |         let screen = xlib::XDefaultScreen(display);
    |                                           ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:118:45
    |
118 |         let win = xlib::XCreateSimpleWindow(display, xlib::XDefaultRootWindow(display),
    |                                             ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:118:79
    |
118 |         let win = xlib::XCreateSimpleWindow(display, xlib::XDefaultRootWindow(display),
    |                                                                               ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:120:58
    |
120 | ...                   xlib::XBlackPixel(display, screen),
    |                                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:121:58
    |
121 | ...                   xlib::XWhitePixel(display, screen));
    |                                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:125:28
    |
125 |         xlib::XSelectInput(display, win, xlib::StructureNotifyMask | xlib::ExposureMask);
    |                            ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:137:29
    |
137 |         xlib::XSetClassHint(display, win, &mut class_hint);
    |                             ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:150:26
    |
150 |         xlib::XSetWMName(display, win, name_property.assume_init_mut());
    |                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:159:26
    |
159 |         xlib::XMapWindow(display, win);
    |                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:162:22
    |
162 |         xlib::XFlush(display);
    |                      ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:203:45
    |
203 |         let root = xlib::XDefaultRootWindow(display);
    |                                             ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:204:51
    |
204 |         let monitors_ptr = xrandr::XRRGetMonitors(display, root, xlib::True, &mut nmonitors);
    |                                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:218:62
    |
218 |         if monitors.is_empty() && xinerama::XineramaIsActive(display) != 0 {
    |                                                              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:220:62
    |
220 |             let screens_raw = xinerama::XineramaQueryScreens(display, &mut screen_count);
    |                                                              ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:228:75
    |
228 |             return vec!(MonitorConfig::from(xlib::XDefaultScreenOfDisplay(display)));
    |                                                                           ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:273:45
    |
273 |         let root = xlib::XDefaultRootWindow(display);
    |                                             ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:276:26
    |
276 |         xlib::XSendEvent(display, root, propagate, mask, &mut event);
    |                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/misc/mod.rs:277:22
    |
277 |         xlib::XFlush(display);
    |                      ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:104:49
    |
104 |             let root = xlib::XDefaultRootWindow(display);
    |                                                 ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:121:58
    |
121 |             x11b.wmcheck_win = xlib::XCreateSimpleWindow(display, root, 0, 0, 1, 1, 0, 0, 0);
    |                                                          ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:122:35
    |
122 |             xlib::XChangeProperty(display, x11b.wmcheck_win, NetSupportingWMCheck.to_xlib_atom(display), xlib::XA_WINDOW,
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:124:35
    |
124 |             xlib::XChangeProperty(display, x11b.wmcheck_win, NetWMName.to_xlib_atom(display),
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:126:35
    |
126 |             xlib::XChangeProperty(display, root, NetSupportingWMCheck.to_xlib_atom(display), xlib::XA_WINDOW,
    |                                   ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:133:73
    |
133 |             (*attributes.as_mut_ptr()).cursor = xlib::XCreateFontCursor(display, CURSOR_NORMAL);
    |                                                                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:136:43
    |
136 |             xlib::XChangeWindowAttributes(display, root, xlib::CWEventMask | xlib::CWCursor, attributes.as_mut_ptr());
    |                                           ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:137:25
    |
137 |             xlib::XSync(display, xlib::False);
    |                         ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> libmars/src/platforms/x11/wm/backend.rs:141:40
    |
141 |                 xrandr::XRRSelectInput(display, root, xrandr::RRCrtcChangeNotifyMask);
    |                                        ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

warning: use of `default` to create a unit struct
   --> libmars/src/platforms/x11/wm/backend.rs:107:47
    |
107 |                 attribute_phantom: PhantomData::default(),
    |                                               ^^^^^^^^^^^ help: remove this call to `default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
    = note: `#[warn(clippy::default_constructed_unit_structs)]` on by default

warning: called `is_some()` after searching an `Iterator` with `find`
   --> libmars/src/platforms/x11/wm/backend.rs:496:47
    |
496 |             if  self.unmanaged_clients.iter().find(|u| u.window() == event.window && u.get_type() == UnmanagedType::Dock).is_some() {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `any(|u| u.window() == event.window && u.get_type() == UnmanagedType::Dock)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some
    = note: `#[warn(clippy::search_is_some)]` on by default

warning: this `match` can be collapsed into the outer `if let`
   --> libmars/src/platforms/x11/wm/backend.rs:618:17
    |
618 | /                 match atom {
619 | |                     WMName => client_rc.borrow_mut().update_title(),
620 | |                     _ => (),
621 | |                 }
    | |_________________^
    |
help: the outer pattern can be modified to include the inner pattern
   --> libmars/src/platforms/x11/wm/backend.rs:617:25
    |
617 |             if let Some(atom) = X11Atom::from_xlib_atom(self.display, event.atom) {
    |                         ^^^^ replace this binding
618 |                 match atom {
619 |                     WMName => client_rc.borrow_mut().update_title(),
    |                     ^^^^^^ with this pattern
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_match
    = note: `#[warn(clippy::collapsible_match)]` on by default

warning: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> libmars/src/platforms/x11/wm/backend.rs:618:17
    |
618 | /                 match atom {
619 | |                     WMName => client_rc.borrow_mut().update_title(),
620 | |                     _ => (),
621 | |                 }
    | |_________________^ help: try: `if atom == WMName { client_rc.borrow_mut().update_title() }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
    = note: `#[warn(clippy::single_match)]` on by default

warning: unneeded `return` statement
   --> libmars/src/platforms/x11/wm/backend.rs:929:5
    |
929 |     return std::any::type_name::<T>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `#[warn(clippy::needless_return)]` on by default
help: remove `return`
    |
929 -     return std::any::type_name::<T>();
929 +     std::any::type_name::<T>()
    |

warning: very complex type used. Consider factoring parts into `type` definitions
  --> libmars/src/platforms/x11/wm/client.rs:42:24
   |
42 |     saved_decorations: Option<(u32, u32, (u32, u32, u32, u32))>,
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
   = note: `#[warn(clippy::type_complexity)]` on by default

warning: `libmars` (lib) generated 15 warnings
error: could not compile `libmars` (lib) due to 75 previous errors; 15 warnings emitted
```